### PR TITLE
Github Action 기반 Discord 알림

### DIFF
--- a/.github/workflows/assigned-issue-notifiaction.yml
+++ b/.github/workflows/assigned-issue-notifiaction.yml
@@ -1,0 +1,37 @@
+name: Assigned Issue Notification
+
+on:
+  issues:
+    types:
+      - assigned
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord Notification
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: "이슈가 할당됐어요 🎉"
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_EMBEDS: |
+            [
+              {
+                "title": "${{ github.event.issue.title }}",
+                "color": 10478271,
+                "description": "${{ github.event.issue.html_url }}",
+                "fields": [
+                  {
+                    "name": "Issue Number",
+                    "value": "#${{ github.event.issue.number }}",
+                    "inline": true
+                  },
+                  {
+                    "name": "Assignee",
+                    "value": "@${{ github.event.issue.assignee.login }}",
+                    "inline": true
+                  }
+                ]
+              }
+            ]

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -16,3 +16,65 @@ jobs:
         uses: norio-nomura/action-swiftlint@3.2.1
         with:
           args: --strict
+
+      - name: Send Success Message
+        if: ${{ success() }}
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: "PR이 성공했어요 👏"
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_EMBEDS: |
+            [
+              {
+                "author": {
+                  "name": "${{ github.event.pull_request.user.login }}"
+                },
+                "title": "#${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}",
+                "color": 10478271,
+                "description": "${{ github.event.pull_request.html_url }}",
+                "fields": [
+                  {
+                    "name": "Base Branch",
+                    "value": "${{ github.base_ref }}",
+                    "inline": true
+                  },
+                  {
+                    "name": "Compare Branch",
+                    "value": "${{ github.head_ref }}",
+                    "inline": true
+                  }
+                ]
+              }
+            ]
+
+      - name: Send Failure Message
+        if: ${{ failure() }}
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: "PR이 실패했어요 😢"
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_EMBEDS: |
+            [
+              {
+                "author": {
+                  "name": "${{ github.event.pull_request.user.login }}"
+                },
+                "title": "#${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}",
+                "color": 13458524,
+                "description": "${{ github.event.pull_request.html_url }}",
+                "fields": [
+                  {
+                    "name": "Base Branch",
+                    "value": "${{ github.base_ref }}",
+                    "inline": true
+                  },
+                  {
+                    "name": "Compare Branch",
+                    "value": "${{ github.head_ref }}",
+                    "inline": true
+                  }
+                ]
+              }
+            ]


### PR DESCRIPTION
### ✅ PR 타입
<!-- 하나 이상의 PR 타입을 선택해 주세요. 그리고 선택하지 않은 항목들은 지워 주세요. -->
- [x] cicd: 지속적 통합 및 배포 작업

### 🪾 반영 브랜치
<!-- 예) feat/login -> main -->
cicd/discord -> main

### ✨ 변경 사항
<!-- 예) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
이슈가 할당되거나 PR이 성공 또는 실패했을 때 Github Action을 이용하여 Discord로 알림을 받을 수 있도록 했습니다.
- 이슈가 할당됐을 때 Discord로 알림 보내는 Github Action용  `yml` 파일 작성                                        
- `ci.yml` 파일에서 PR이 성공했을 때 Discord로 알림 보내는 기능 추가                                              
- `ci.yml` 파일에서 PR이 실패했을 때 Discord로 알림 보내는 기능 추가

### 💯 테스트 결과
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
<img width="364" alt="Screenshot 2025-05-22 at 6 13 51 PM" src="https://github.com/user-attachments/assets/4f4bfda1-d63b-4928-95a2-eaf454b846d9" />
<img width="364" alt="Screenshot 2025-05-22 at 6 14 16 PM" src="https://github.com/user-attachments/assets/3987f8f5-2a3a-42e6-a3b6-ff282d6ebc64" />

### 📂 관련 이슈
<!-- 예) #5 -->
#8 

### 👀 리뷰어에게
<!-- 리뷰 시 중점적으로 봐야 할 부분이나 우려되는 사항이 있다면 적어 주세요. -->
