### PR TITLE
Ensure simulator is reset before running tests

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,7 @@ platform :ios do
     scan(
       scheme: SCHEME_NAME,
       destination: 'platform=iOS Simulator,name=iPhone 16',
+      reset_simulator: true,
       result_bundle: true,
       code_coverage: true,
       output_directory: ".",


### PR DESCRIPTION
### ✅ PR 타입
<!-- 하나 이상의 PR 타입을 선택해 주세요. 그리고 선택하지 않은 항목들은 지워 주세요. -->
- [ ] fix: 버그 수정

### 🪾 반영 브랜치
<!-- 예) feat/login -> main -->
#28-ui-test -> dev

### ✨ 변경 사항
<!-- 예) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.-->
Fastlane에서 테스트 실행 전 시뮬레이터를 초기화하는 옵션을 추가했습니다.

### 💯 테스트 결과
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
```
bundle exec fastlane test
[✔] 🚀 
[11:56:38]: ------------------------------
[11:56:38]: --- Step: default_platform ---
[11:56:38]: ------------------------------
[11:56:38]: Driving the lane 'ios test' 🚀
[11:56:38]: ------------------
[11:56:38]: --- Step: scan ---
[11:56:38]: ------------------
[11:56:38]: Resolving Swift Package Manager dependencies...
[11:56:38]: $ xcodebuild -resolvePackageDependencies -scheme BeforeGoing -project ./BeforeGoing.xcodeproj -destination platform\=iOS\ Simulator,name\=iPhone\ 16
[11:56:38]: ▸ Command line invocation:
[11:56:38]: ▸     /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -resolvePackageDependencies -scheme BeforeGoing -project ./BeforeGoing.xcodeproj -destination "platform=iOS Simulator,name=iPhone 16"
[11:56:39]: ▸ Resolve Package Graph
[11:56:39]: ▸ Resolved source packages:
[11:56:39]: ▸   Alamofire: https://github.com/Alamofire/Alamofire.git @ 5.10.2
[11:56:39]: ▸   KakaoOpenSDK: https://github.com/kakao/kakao-ios-sdk @ master (787763e)
[11:56:39]: ▸   Then: https://github.com/devxoul/Then.git @ 3.0.0
[11:56:39]: ▸   SnapKit: https://github.com/SnapKit/SnapKit.git @ 5.7.1
[11:56:39]: ▸ resolved source packages: Alamofire, KakaoOpenSDK, Then, SnapKit
[11:56:39]: $ xcodebuild -showBuildSettings -scheme BeforeGoing -project ./BeforeGoing.xcodeproj -destination platform\=iOS\ Simulator,name\=iPhone\ 16 2>&1
nil versions are discouraged and will be deprecated in Rubygems 4
[11:56:41]: Found simulator "iPhone 16 Pro (18.6)"

+---------------------------------------------------------------------------------------------------------------------+
|                                              Summary for scan 2.228.0                                               |
+------------------------------------------------+--------------------------------------------------------------------+
| scheme                                         | BeforeGoing                                                        |
| result_bundle                                  | true                                                               |
| code_coverage                                  | true                                                               |
| output_directory                               | .                                                                  |
| output_types                                   | junit,xcresult                                                     |
| project                                        | ./BeforeGoing.xcodeproj                                            |
| skip_detect_devices                            | false                                                              |
| ensure_devices_found                           | false                                                              |
| force_quit_simulator                           | false                                                              |
| reset_simulator                                | false                                                              |
| disable_slide_to_type                          | true                                                               |
| reinstall_app                                  | false                                                              |
| app_identifier                                 | com.und.BeforeGoing                                                |
| clean                                          | false                                                              |
| open_report                                    | false                                                              |
| buildlog_path                                  | ~/Library/Logs/scan                                                |
| include_simulator_logs                         | false                                                              |
| xcodebuild_formatter                           | xcpretty                                                           |
| output_remove_retry_attempts                   | false                                                              |
| derived_data_path                              | /Users/chori/Library/Developer/Xcode/DerivedData/BeforeGoing-hktj  |
|                                                | wicekvwpzbbmmmfkhbfbcbkh                                           |
| should_zip_build_products                      | false                                                              |
| output_xctestrun                               | false                                                              |
| use_clang_report_name                          | false                                                              |
| disable_concurrent_testing                     | false                                                              |
| skip_build                                     | false                                                              |
| slack_use_webhook_configured_username_and_icon | false                                                              |
| slack_username                                 | fastlane                                                           |
| slack_icon_url                                 | https://fastlane.tools/assets/img/fastlane_icon.png                |
| skip_slack                                     | false                                                              |
| slack_only_on_failure                          | false                                                              |
| run_rosetta_simulator                          | false                                                              |
| xcodebuild_command                             | env NSUnbufferedIO=YES xcodebuild                                  |
| skip_package_dependencies_resolution           | false                                                              |
| disable_package_automatic_updates              | false                                                              |
| use_system_scm                                 | false                                                              |
| number_of_retries                              | 0                                                                  |
| fail_build                                     | true                                                               |
| xcode_path                                     | /Applications/Xcode.app                                            |
+------------------------------------------------+--------------------------------------------------------------------+

[11:56:41]: Disabling 'Slide to Type' iPhone 16 Pro
[11:56:41]: $ /usr/libexec/PlistBuddy -c "Add :KeyboardContinuousPathEnabled bool false" /Users/chori/Library/Developer/CoreSimulator/Devices/345E0D95-C60A-4936-BA13-F364B0977D33/data/Library/Preferences/com.apple.keyboard.ContinuousPath.plist >/dev/null 2>&1
[11:56:41]: Couldn't find reporter 'xcresult', available html, junit, json-compilation-database
[11:56:41]: $ set -o pipefail && env NSUnbufferedIO=YES xcodebuild -scheme BeforeGoing -project ./BeforeGoing.xcodeproj -derivedDataPath /Users/chori/Library/Developer/Xcode/DerivedData/BeforeGoing-hktjwicekvwpzbbmmmfkhbfbcbkh -destination 'platform=iOS Simulator,name=iPhone 16' -resultBundlePath ./BeforeGoing.xcresult -enableCodeCoverage YES build test | tee '/Users/chori/Library/Logs/scan/BeforeGoing-BeforeGoing.log' | xcpretty  --report junit --output '/Users/chori/Desktop/workspace/swift/beforegoing-ios/report.junit' --report junit --output '/var/folders/47/9lmrmhln3xbc4vvbwl6ds83c0000gn/T/junit_report20250831-75121-8f33tq' 
[11:56:41]: ▸ Loading...
[11:56:42]: ▸ --- xcodebuild: WARNING: Using the first of multiple matching destinations:
[11:56:42]: ▸ { platform:iOS Simulator, arch:arm64, id:A00155A6-1FA9-426D-B484-A0332780B102, OS:18.6, name:iPhone 16 }
[11:56:42]: ▸ { platform:iOS Simulator, arch:x86_64, id:A00155A6-1FA9-426D-B484-A0332780B102, OS:18.6, name:iPhone 16 }
[11:56:48]: ▸ Processing empty-KakaoOpenSDK_KakaoSDKCommon.plist
[11:56:48]: ▸ Processing empty-SnapKit_SnapKit.plist
[11:56:48]: ▸ Processing empty-Alamofire_Alamofire.plist
[11:56:48]: ▸ Processing Info.plist
[11:56:48]: ▸ Linking BeforeGoing.debug.dylib
[11:56:48]: ▸ Linking BeforeGoing
[11:56:48]: ▸ Build Succeeded
[11:56:48]: ▸ --- xcodebuild: WARNING: Using the first of multiple matching destinations:
[11:56:48]: ▸ { platform:iOS Simulator, arch:arm64, id:A00155A6-1FA9-426D-B484-A0332780B102, OS:18.6, name:iPhone 16 }
[11:56:48]: ▸ { platform:iOS Simulator, arch:x86_64, id:A00155A6-1FA9-426D-B484-A0332780B102, OS:18.6, name:iPhone 16 }
[11:56:49]: ▸ Processing empty-SnapKit_SnapKit.plist
[11:56:49]: ▸ Processing empty-KakaoOpenSDK_KakaoSDKCommon.plist
[11:56:49]: ▸ Processing empty-Alamofire_Alamofire.plist
[11:56:49]: ▸ Linking BeforeGoing.debug.dylib
[11:56:50]: ▸ Processing Info.plist
[11:56:50]: ▸ Linking BeforeGoing
[11:56:50]: ▸ Linking BeforeGoingTests
[11:56:50]: ▸ Processing empty-BeforeGoingTests.plist
[11:56:50]: Running Tests: ▸ Touching BeforeGoingTests.xctest (in target 'BeforeGoingTests' from project 'BeforeGoing')
[11:56:50]: ▸ Processing empty-BeforeGoingUITests.plist
[11:58:12]: ▸ 2025-08-31 11:58:12.693 xcodebuild[75205:1606613] [MT] IDETestOperationsObserverDebug: 82.093 elapsed -- Testing started completed.
[11:58:12]: ▸ 2025-08-31 11:58:12.694 xcodebuild[75205:1606613] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
[11:58:12]: ▸ 2025-08-31 11:58:12.694 xcodebuild[75205:1606613] [MT] IDETestOperationsObserverDebug: 82.093 sec, +82.093 sec -- end
[11:58:12]: ▸ Test Succeeded
+-------------------------+
|      Test Results       |
+--------------------+----+
| Number of tests    | 19 |
| Number of failures | 0  |
+--------------------+----+


+---------------------------------------+
|           fastlane summary            |
+------+------------------+-------------+
| Step | Action           | Time (in s) |
+------+------------------+-------------+
| 1    | default_platform | 0           |
| 2    | scan             | 99          |
+------+------------------+-------------+

[11:58:17]: fastlane.tools finished successfully 🎉
```

### 📂 관련 이슈
<!-- 예) #5 -->
#28 

### 👀 리뷰어에게
<!-- 리뷰 시 중점적으로 봐야 할 부분이나 우려되는 사항이 있다면 적어 주세요. -->
