### PR TITLE
Feat/#47 자동 로그인 구현

### DIFF
--- a/BeforeGoing.xcodeproj/project.pbxproj
+++ b/BeforeGoing.xcodeproj/project.pbxproj
@@ -45,6 +45,20 @@
 			);
 			target = 186E06DA2DDDF10500E32490 /* BeforeGoing */;
 		};
+		18A2D9742E7E317C0034D7B9 /* Exceptions for "BeforeGoing" folder in "BeforeGoingTests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Data/Config.xcconfig,
+			);
+			target = 186E06F02DDDF10600E32490 /* BeforeGoingTests */;
+		};
+		18A2D9752E7E317C0034D7B9 /* Exceptions for "BeforeGoing" folder in "BeforeGoingUITests" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Data/Config.xcconfig,
+			);
+			target = 186E06FA2DDDF10600E32490 /* BeforeGoingUITests */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -52,6 +66,8 @@
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				186E07032DDDF10600E32490 /* Exceptions for "BeforeGoing" folder in "BeforeGoing" target */,
+				18A2D9742E7E317C0034D7B9 /* Exceptions for "BeforeGoing" folder in "BeforeGoingTests" target */,
+				18A2D9752E7E317C0034D7B9 /* Exceptions for "BeforeGoing" folder in "BeforeGoingUITests" target */,
 			);
 			path = BeforeGoing;
 			sourceTree = "<group>";
@@ -306,7 +322,7 @@
 		186E07052DDDF10600E32490 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 186E06DD2DDDF10500E32490 /* BeforeGoing */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Data/Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -342,7 +358,7 @@
 		186E07062DDDF10600E32490 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 186E06DD2DDDF10500E32490 /* BeforeGoing */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Data/Config.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -378,7 +394,7 @@
 		186E07072DDDF10600E32490 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 186E06DD2DDDF10500E32490 /* BeforeGoing */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Data/Config.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -443,7 +459,7 @@
 		186E07082DDDF10600E32490 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 186E06DD2DDDF10500E32490 /* BeforeGoing */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Data/Config.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -501,7 +517,7 @@
 		186E070A2DDDF10600E32490 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 186E06DD2DDDF10500E32490 /* BeforeGoing */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Data/Config.xcconfig;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -524,7 +540,7 @@
 		186E070B2DDDF10600E32490 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 186E06DD2DDDF10500E32490 /* BeforeGoing */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Data/Config.xcconfig;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -547,7 +563,7 @@
 		186E070D2DDDF10600E32490 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 186E06DD2DDDF10500E32490 /* BeforeGoing */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Data/Config.xcconfig;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -568,7 +584,7 @@
 		186E070E2DDDF10600E32490 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 186E06DD2DDDF10500E32490 /* BeforeGoing */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Data/Config.xcconfig;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;

--- a/BeforeGoing/Data/DataDependencyAssembler.swift
+++ b/BeforeGoing/Data/DataDependencyAssembler.swift
@@ -44,6 +44,7 @@ struct DataDependencyAssembler: DependencyAssembler {
             TermsRepository(
                 networkService: networkService,
                 keyChainService: keyChainService,
+                userDefaultsService: userDefaultsService,
                 termsRequestMapper: termsRequestMapper,
                 updateTermRequestMapper: updateTermRequestMapper
             )

--- a/BeforeGoing/Data/DataDependencyAssembler.swift
+++ b/BeforeGoing/Data/DataDependencyAssembler.swift
@@ -16,6 +16,7 @@ struct DataDependencyAssembler: DependencyAssembler {
     private let termsRequestMapper = TermsRequestMapper()
     private let updateTermRequestMapper = UpdateTermRequestMapper()
     private let updateNicknameRequestMapper = UpdateNicknameRequestMapper()
+    private let tokenValidator = TokenValidator()
     
     init() {
         self.tokenReissuer = TokenReissuer(keyChainService: keyChainService)
@@ -33,8 +34,10 @@ struct DataDependencyAssembler: DependencyAssembler {
                 networkService: networkService,
                 tokenReissuer: tokenReissuer,
                 keyChainService: keyChainService,
+                userDefaultsService: userDefaultsService,
                 nonceRequestMapper: nonceRequestMapper,
-                loginRequestMapper: loginRequestMapper
+                loginRequestMapper: loginRequestMapper,
+                tokenValidator: tokenValidator
             )
         }
         DIContainer.shared.register(type: TermsInterface.self) { _ in

--- a/BeforeGoing/Data/Network/Service/API/AuthAPI.swift
+++ b/BeforeGoing/Data/Network/Service/API/AuthAPI.swift
@@ -4,7 +4,7 @@ enum AuthAPI {
     case kakaoLogin(dto: LoginRequestDTO)
     case nonce(dto: NonceRequestDTO)
     case tokens(dto: TokensRequestDTO)
-    case logout
+    case logout(accessToken: String)
 }
 
 extension AuthAPI: EndPoint {
@@ -42,7 +42,15 @@ extension AuthAPI: EndPoint {
     }
 
     var headers: HTTPHeaders? {
-        ["Content-Type": "application/json"]
+        switch self {
+        case .kakaoLogin, .nonce, .tokens:
+            ["Content-Type": "application/json"]
+        case .logout(let accessToken):
+            [
+                "Content-Type": "application/json",
+                "Authorization": "Bearer \(accessToken)"
+            ]
+        }
     }
 
     var parameterEncoding: any ParameterEncoding {

--- a/BeforeGoing/Data/Persistence/Service/KeyChainKey.swift
+++ b/BeforeGoing/Data/Persistence/Service/KeyChainKey.swift
@@ -1,3 +1,6 @@
 enum KeyChainKey: String, CaseIterable {
-    case accessToken, refreshToken
+    case accessToken
+    case refreshToken
+    case accessTokenExpirationDate
+    case refreshTokenExpirationDate
 }

--- a/BeforeGoing/Data/Persistence/Service/UserDefaultsKey.swift
+++ b/BeforeGoing/Data/Persistence/Service/UserDefaultsKey.swift
@@ -6,5 +6,6 @@
 //
 
 enum UserDefaultsKey: String, CaseIterable {
+    case isCompletedAgreeTerms
     case memberName
 }

--- a/BeforeGoing/Data/Repository/AuthRepository.swift
+++ b/BeforeGoing/Data/Repository/AuthRepository.swift
@@ -65,10 +65,10 @@ struct AuthRepository: AuthInterface {
             return false
         }
         
-        if !tokenValidator.isTokenValid(
-            accessTokenExpirationDate: accessTokenExpirationDate,
-            refreshTokenExpirationDate: refreshTokenExpirationDate
-        ) {
+        if !tokenValidator.isAccessTokenValid(expirationDate: accessTokenExpirationDate) {
+            guard tokenValidator.isRefreshTokenValid(expirationDate: refreshTokenExpirationDate) else {
+                return false
+            }
             try await tokenReissuer.reissue()
         }
         return true

--- a/BeforeGoing/Data/Repository/AuthRepository.swift
+++ b/BeforeGoing/Data/Repository/AuthRepository.swift
@@ -10,21 +10,27 @@ struct AuthRepository: AuthInterface {
     private let networkService: NetworkService
     private let tokenReissuer: TokenReissuer
     private let keyChainService: KeyChainService
+    private let userDefaultsService: UserDefaultsService
     private let nonceRequestMapper: NonceRequestMapper
     private let loginRequestMapper: LoginRequestMapper
+    private let tokenValidator: TokenValidator
     
     init(
         networkService: NetworkService,
         tokenReissuer: TokenReissuer,
         keyChainService: KeyChainService,
+        userDefaultsService: UserDefaultsService,
         nonceRequestMapper: NonceRequestMapper,
-        loginRequestMapper: LoginRequestMapper
+        loginRequestMapper: LoginRequestMapper,
+        tokenValidator: TokenValidator
     ) {
         self.networkService = networkService
         self.tokenReissuer = tokenReissuer
         self.keyChainService = keyChainService
+        self.userDefaultsService = userDefaultsService
         self.nonceRequestMapper = nonceRequestMapper
         self.loginRequestMapper = loginRequestMapper
+        self.tokenValidator = tokenValidator
     }
     
     func requestNonce(provider: String) async throws -> NonceEntity {
@@ -40,45 +46,74 @@ struct AuthRepository: AuthInterface {
         return try await networkService.requestKakaoIDToken(nonce: nonce)
     }
     
-    func requestKakaoLogin(provider: String, idToken: String) async throws {
+    func requestKakaoLogin(provider: String, idToken: String) async throws -> Bool {
         let requestDTO = loginRequestMapper.map((provider, idToken))
         let response = try await networkService.request(
             endPoint: AuthAPI.kakaoLogin(dto: requestDTO),
             responseType: LoginResponseDTO.self
         )
-        // 기존 가입 여부에 따른 분기 처리
         saveKeyChain(response: response)
-    }
-    
-    private func saveKeyChain(response: LoginResponseDTO) {
-        keyChainService.save(response.accessToken, forKey: .accessToken)
-        keyChainService.save(response.refreshToken, forKey: .refreshToken)
+        
+        return isMemberNameSet
     }
     
     func autoLogin() async throws -> Bool {
-        guard let accessToken = keyChainService.load(key: .accessToken),
-              let refreshToken = keyChainService.load(key: .refreshToken),
-              !accessToken.isEmpty,
-              !refreshToken.isEmpty else {
-            
+        guard isTokenExists, isMemberNameSet else { return false }
+        
+        guard let accessTokenExpirationDate = keyChainService.load(key: .accessTokenExpirationDate),
+              let refreshTokenExpirationDate = keyChainService.load(key: .refreshTokenExpirationDate) else {
             return false
         }
-        do {
+        
+        if !tokenValidator.isTokenValid(
+            accessTokenExpirationDate: accessTokenExpirationDate,
+            refreshTokenExpirationDate: refreshTokenExpirationDate
+        ) {
             try await tokenReissuer.reissue()
-            return true
-        } catch {
-            BeforeGoingLogger.error(BeforeGoingError.reissueTokenFailed)
-            return false
         }
+        return true
     }
     
     func logout() async throws {
-        try await networkService.request(endPoint: AuthAPI.logout)
+        guard let accessToken = keyChainService.load(key: .accessToken) else {
+            BeforeGoingLogger.error(BeforeGoingError.accessTokenMissing)
+            return
+        }
+        try await networkService.request(endPoint: AuthAPI.logout(accessToken: accessToken))
         deleteUserInformation()
     }
     
-    func deleteUserInformation() {
-        keyChainService.delete(key: .accessToken)
-        keyChainService.delete(key: .refreshToken)
+    private func saveKeyChain(response: LoginResponseDTO) {
+        let responseData: [KeyChainKey: String] = [
+            .accessToken: response.accessToken,
+            .refreshToken: response.refreshToken,
+            .accessTokenExpirationDate: tokenValidator.calculateExpirationDate(expiresIn: response.accessTokenExpiresIn),
+            .refreshTokenExpirationDate: tokenValidator.calculateExpirationDate(expiresIn: response.refreshTokenExpiresIn)
+        ]
+        
+        for data in responseData {
+            keyChainService.save(data.value, forKey: data.key)
+        }
+    }
+    
+    private var isTokenExists: Bool {
+        if let accessToken = keyChainService.load(key: .accessToken),
+           let refreshToken = keyChainService.load(key: .refreshToken),
+           !accessToken.isEmpty,
+           !refreshToken.isEmpty {
+            return true
+        }
+        return false
+    }
+    
+    private var isMemberNameSet: Bool {
+        let memberName: String? = userDefaultsService.load(key: .memberName)
+        return memberName != nil
+    }
+    
+    private func deleteUserInformation() {
+        for key in KeyChainKey.allCases {
+            keyChainService.delete(key: key)
+        }
     }
 }

--- a/BeforeGoing/Data/Repository/TermsRepository.swift
+++ b/BeforeGoing/Data/Repository/TermsRepository.swift
@@ -9,17 +9,20 @@ struct TermsRepository: TermsInterface {
     
     private let networkService: NetworkService
     private let keyChainService: KeyChainService
+    private let userDefaultsService: UserDefaultsService
     private let termsRequestMapper: TermsRequestMapper
     private let updateTermRequestMapper: UpdateTermRequestMapper
     
     init(
         networkService: NetworkService,
         keyChainService: KeyChainService,
+        userDefaultsService: UserDefaultsService,
         termsRequestMapper: TermsRequestMapper,
         updateTermRequestMapper: UpdateTermRequestMapper
     ) {
         self.networkService = networkService
         self.keyChainService = keyChainService
+        self.userDefaultsService = userDefaultsService
         self.termsRequestMapper = termsRequestMapper
         self.updateTermRequestMapper = updateTermRequestMapper
     }
@@ -48,6 +51,11 @@ struct TermsRepository: TermsInterface {
             return
         }
         
+        if let _: Bool = userDefaultsService.load(key: .isCompletedAgreeTerms) {
+            try await updateAgreementTerm(eventPushAgreed: eventPushAgreed)
+            return
+        }
+        
         let requestDTO = termsRequestMapper.map(
             (
                 termsOfServiceAgreed: termsOfServiceAgreed,
@@ -60,6 +68,8 @@ struct TermsRepository: TermsInterface {
             endPoint: TermsAPI.sendTerms(accessToken: accessToken, dto: requestDTO),
             responseType: TermsResponseDTO.self
         )
+        
+        let _ = userDefaultsService.save(true, key: .isCompletedAgreeTerms)
     }
     
     func updateAgreementTerm(eventPushAgreed: Bool) async throws {

--- a/BeforeGoing/Data/Util/TokenValidator.swift
+++ b/BeforeGoing/Data/Util/TokenValidator.swift
@@ -1,0 +1,41 @@
+//
+//  TokenValidator.swift
+//  BeforeGoing
+//
+//  Created by APPLE on 9/20/25.
+//
+
+import Foundation
+
+struct TokenValidator {
+    
+    private let dateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return dateFormatter
+    }()
+    
+    func isTokenValid(accessTokenExpirationDate: String, refreshTokenExpirationDate: String) -> Bool {
+        guard let accessTokenExpirationDate = dateFormatter.date(from: accessTokenExpirationDate),
+              let refreshTokenExpirationDate = dateFormatter.date(from: refreshTokenExpirationDate) else {
+            return false
+        }
+        
+        return !isTokensExpired(
+            accessTokenExpirationDate: accessTokenExpirationDate,
+            refreshTokenExpirationDate: refreshTokenExpirationDate
+        )
+    }
+    
+    func calculateExpirationDate(expiresIn: Int) -> String {
+        let currentDate = Date()
+        let expirationDate = currentDate.addingTimeInterval(TimeInterval(expiresIn))
+        
+        return dateFormatter.string(from: expirationDate)
+    }
+    
+    private func isTokensExpired(accessTokenExpirationDate: Date, refreshTokenExpirationDate: Date) -> Bool {
+        let currentDate = Date()
+        return accessTokenExpirationDate < currentDate && refreshTokenExpirationDate < currentDate
+    }
+}

--- a/BeforeGoing/Data/Util/TokenValidator.swift
+++ b/BeforeGoing/Data/Util/TokenValidator.swift
@@ -15,16 +15,18 @@ struct TokenValidator {
         return dateFormatter
     }()
     
-    func isTokenValid(accessTokenExpirationDate: String, refreshTokenExpirationDate: String) -> Bool {
-        guard let accessTokenExpirationDate = toDate(accessTokenExpirationDate),
-              let refreshTokenExpirationDate = toDate(refreshTokenExpirationDate) else {
+    func isAccessTokenValid(expirationDate: String) -> Bool {
+        guard let date = toDate(expirationDate) else {
             return false
         }
-        
-        return !isTokensExpired(
-            accessTokenExpirationDate: accessTokenExpirationDate,
-            refreshTokenExpirationDate: refreshTokenExpirationDate
-        )
+        return date > Date()
+    }
+    
+    func isRefreshTokenValid(expirationDate: String) -> Bool {
+        guard let date = toDate(expirationDate) else {
+            return false
+        }
+        return date > Date()
     }
     
     func calculateExpirationDate(expiresIn: Int) -> String {
@@ -36,10 +38,5 @@ struct TokenValidator {
     
     private func toDate(_ dateString: String) -> Date? {
         dateFormatter.date(from: dateString)
-    }
-    
-    private func isTokensExpired(accessTokenExpirationDate: Date, refreshTokenExpirationDate: Date) -> Bool {
-        let currentDate = Date()
-        return accessTokenExpirationDate < currentDate && refreshTokenExpirationDate < currentDate
     }
 }

--- a/BeforeGoing/Data/Util/TokenValidator.swift
+++ b/BeforeGoing/Data/Util/TokenValidator.swift
@@ -16,8 +16,8 @@ struct TokenValidator {
     }()
     
     func isTokenValid(accessTokenExpirationDate: String, refreshTokenExpirationDate: String) -> Bool {
-        guard let accessTokenExpirationDate = dateFormatter.date(from: accessTokenExpirationDate),
-              let refreshTokenExpirationDate = dateFormatter.date(from: refreshTokenExpirationDate) else {
+        guard let accessTokenExpirationDate = toDate(accessTokenExpirationDate),
+              let refreshTokenExpirationDate = toDate(refreshTokenExpirationDate) else {
             return false
         }
         
@@ -32,6 +32,10 @@ struct TokenValidator {
         let expirationDate = currentDate.addingTimeInterval(TimeInterval(expiresIn))
         
         return dateFormatter.string(from: expirationDate)
+    }
+    
+    private func toDate(_ dateString: String) -> Date? {
+        dateFormatter.date(from: dateString)
     }
     
     private func isTokensExpired(accessTokenExpirationDate: Date, refreshTokenExpirationDate: Date) -> Bool {

--- a/BeforeGoing/Domain/DomainDependencyAssembler.swift
+++ b/BeforeGoing/Domain/DomainDependencyAssembler.swift
@@ -16,23 +16,6 @@ final class DomainDependencyAssembler: DependencyAssembler {
     }
     
     func assemble() {
-        dataDependencyAssembler.assemble()
-        
-        guard let authrepository = DIContainer.shared.resolve(type: AuthInterface.self) else {
-            BeforeGoingLogger.error(BeforeGoingError.diContainerError)
-            return
-        }
-        
-        guard let termsRepository = DIContainer.shared.resolve(type: TermsInterface.self) else {
-            BeforeGoingLogger.error(BeforeGoingError.diContainerError)
-            return
-        }
-        
-        guard let memberRepository = DIContainer.shared.resolve(type: MemberInterface.self) else {
-            BeforeGoingLogger.error(BeforeGoingError.diContainerError)
-            return
-        }
-        
         let isUITestWithMock = ProcessInfo.processInfo.environment["USE_MOCK"] == "true"
         
         if isUITestWithMock {
@@ -48,6 +31,23 @@ final class DomainDependencyAssembler: DependencyAssembler {
             DIContainer.shared.register(type: GetMemberNameType.self) { _ in MockGetMemberNameUseCase() }
             DIContainer.shared.register(type: MemberWithdrawType.self) { _ in MockMemberWithdrawUseCase() }
             
+            return
+        }
+        
+        dataDependencyAssembler.assemble()
+        
+        guard let authrepository = DIContainer.shared.resolve(type: AuthInterface.self) else {
+            BeforeGoingLogger.error(BeforeGoingError.diContainerError)
+            return
+        }
+        
+        guard let termsRepository = DIContainer.shared.resolve(type: TermsInterface.self) else {
+            BeforeGoingLogger.error(BeforeGoingError.diContainerError)
+            return
+        }
+        
+        guard let memberRepository = DIContainer.shared.resolve(type: MemberInterface.self) else {
+            BeforeGoingLogger.error(BeforeGoingError.diContainerError)
             return
         }
         

--- a/BeforeGoing/Domain/DomainDependencyAssembler.swift
+++ b/BeforeGoing/Domain/DomainDependencyAssembler.swift
@@ -33,26 +33,52 @@ final class DomainDependencyAssembler: DependencyAssembler {
             return
         }
         
-        let isUITestWithMock = ProcessInfo.processInfo.environment["USE_MOCK_AUTOLOGIN"] == "true"
-
+        let isUITestWithMock = ProcessInfo.processInfo.environment["USE_MOCK"] == "true"
+        
         if isUITestWithMock {
-            DIContainer.shared.register(type: AutoLoginType.self) { _ in
-                return MockAutoLoginUseCase()
-            }
-        } else {
-            DIContainer.shared.register(type: AutoLoginType.self) { _ in
-                return AutoLoginUseCase(repository: authrepository)
-            }
+            DIContainer.shared.register(type: AutoLoginType.self) { _ in MockAutoLoginUseCase() }
+            DIContainer.shared.register(type: KakaoLoginType.self) { _ in MockKakaoLoginUseCase() }
+            DIContainer.shared.register(type: LogoutType.self) { _ in MockLogoutUseCase() }
+            
+            DIContainer.shared.register(type: FetchAgreeTermsType.self) { _ in MockFetchAgreeTermsUseCase() }
+            DIContainer.shared.register(type: SendAgreeTermsType.self) { _ in MockSendAgreeTermsUseCase() }
+            DIContainer.shared.register(type: UpdatePushNoticeType.self) { _ in MockUpdatePushNoticeUseCase() }
+            
+            DIContainer.shared.register(type: UpdateNicknameType.self) { _ in MockUpdateNicknameUseCase() }
+            DIContainer.shared.register(type: GetMemberNameType.self) { _ in MockGetMemberNameUseCase() }
+            DIContainer.shared.register(type: MemberWithdrawType.self) { _ in MockMemberWithdrawUseCase() }
+            
+            return
         }
-        DIContainer.shared.register(KakaoLoginUseCase(repository: authrepository))
-        DIContainer.shared.register(LogoutUseCase(repository: authrepository))
         
-        DIContainer.shared.register(FetchAgreeTermsUseCase(repository: termsRepository))
-        DIContainer.shared.register(SendAgreeTermsUseCase(repository: termsRepository))
-        DIContainer.shared.register(UpdatePushNoticeUseCase(repository: termsRepository))
+        DIContainer.shared.register(type: AutoLoginType.self) { _ in
+            AutoLoginUseCase(repository: authrepository)
+        }
+        DIContainer.shared.register(type: KakaoLoginType.self) { _ in
+            return KakaoLoginUseCase(repository: authrepository)
+        }
+        DIContainer.shared.register(type: LogoutType.self) { _ in
+            return LogoutUseCase(repository: authrepository)
+        }
         
-        DIContainer.shared.register(UpdateNicknameUseCase(repository: memberRepository))
-        DIContainer.shared.register(GetMemberNameUseCase(repository: memberRepository))
-        DIContainer.shared.register(MemberWithdrawUseCase(repository: memberRepository))
+        DIContainer.shared.register(type: FetchAgreeTermsType.self) { _ in
+            return FetchAgreeTermsUseCase(repository: termsRepository)
+        }
+        DIContainer.shared.register(type: SendAgreeTermsType.self) { _ in
+            return SendAgreeTermsUseCase(repository: termsRepository)
+        }
+        DIContainer.shared.register(type: UpdatePushNoticeType.self) { _ in
+            return UpdatePushNoticeUseCase(repository: termsRepository)
+        }
+        
+        DIContainer.shared.register(type: UpdateNicknameType.self) { _ in
+            return UpdateNicknameUseCase(repository: memberRepository)
+        }
+        DIContainer.shared.register(type: GetMemberNameType.self) { _ in
+            return GetMemberNameUseCase(repository: memberRepository)
+        }
+        DIContainer.shared.register(type: MemberWithdrawType.self) { _ in
+            return MemberWithdrawUseCase(repository: memberRepository)
+        }
     }
 }

--- a/BeforeGoing/Domain/DomainDependencyAssembler.swift
+++ b/BeforeGoing/Domain/DomainDependencyAssembler.swift
@@ -5,6 +5,8 @@
 //  Created by APPLE on 9/14/25.
 //
 
+import Foundation
+
 final class DomainDependencyAssembler: DependencyAssembler {
     
     private let dataDependencyAssembler: DataDependencyAssembler
@@ -31,7 +33,17 @@ final class DomainDependencyAssembler: DependencyAssembler {
             return
         }
         
-        DIContainer.shared.register(AutoLoginUseCase(repository: authrepository))
+        let isUITestWithMock = ProcessInfo.processInfo.environment["USE_MOCK_AUTOLOGIN"] == "true"
+
+        if isUITestWithMock {
+            DIContainer.shared.register(type: AutoLoginType.self) { _ in
+                return MockAutoLoginUseCase()
+            }
+        } else {
+            DIContainer.shared.register(type: AutoLoginType.self) { _ in
+                return AutoLoginUseCase(repository: authrepository)
+            }
+        }
         DIContainer.shared.register(KakaoLoginUseCase(repository: authrepository))
         DIContainer.shared.register(LogoutUseCase(repository: authrepository))
         

--- a/BeforeGoing/Domain/Entity/TermsEntity.swift
+++ b/BeforeGoing/Domain/Entity/TermsEntity.swift
@@ -13,3 +13,17 @@ struct TermsEntity {
     let isOver14: Bool
     let eventPushAgreed: Bool
 }
+
+extension TermsEntity {
+    
+    static func stub() -> Self {
+        return TermsEntity(
+            id: 1,
+            memberId: 1,
+            termsOfServiceAgreed: true,
+            privacyPolicyAgreed: true,
+            isOver14: true,
+            eventPushAgreed: true
+        )
+    }
+}

--- a/BeforeGoing/Domain/Interface/AuthInterface.swift
+++ b/BeforeGoing/Domain/Interface/AuthInterface.swift
@@ -9,7 +9,7 @@ protocol AuthInterface {
     
     func requestNonce(provider: String) async throws -> NonceEntity
     func requestIDToken(nonce: String?) async throws -> String
-    func requestKakaoLogin(provider: String, idToken: String) async throws
+    func requestKakaoLogin(provider: String, idToken: String) async throws -> Bool
     func autoLogin() async throws -> Bool
     func logout() async throws
 }

--- a/BeforeGoing/Domain/UseCase/AutoLoginUseCase.swift
+++ b/BeforeGoing/Domain/UseCase/AutoLoginUseCase.swift
@@ -5,7 +5,11 @@
 //  Created by APPLE on 9/12/25.
 //
 
-struct AutoLoginUseCase {
+protocol AutoLoginType {
+    func execute() async throws -> Bool
+}
+
+struct AutoLoginUseCase: AutoLoginType {
     
     private let repository: AuthInterface
     
@@ -15,5 +19,11 @@ struct AutoLoginUseCase {
     
     func execute() async throws -> Bool {
         return try await repository.autoLogin()
+    }
+}
+
+struct MockAutoLoginUseCase: AutoLoginType {
+    func execute() -> Bool {
+        return true
     }
 }

--- a/BeforeGoing/Domain/UseCase/FetchAgreeTermsUseCase.swift
+++ b/BeforeGoing/Domain/UseCase/FetchAgreeTermsUseCase.swift
@@ -5,7 +5,11 @@
 //  Created by APPLE on 9/18/25.
 //
 
-struct FetchAgreeTermsUseCase {
+protocol FetchAgreeTermsType {
+    func execute() async throws -> TermsEntity?
+}
+
+struct FetchAgreeTermsUseCase: FetchAgreeTermsType {
     
     private let repository: TermsInterface
     
@@ -18,5 +22,12 @@ struct FetchAgreeTermsUseCase {
             return nil
         }
         return result
+    }
+}
+
+struct MockFetchAgreeTermsUseCase: FetchAgreeTermsType {
+    
+    func execute() -> TermsEntity? {
+        return .stub()
     }
 }

--- a/BeforeGoing/Domain/UseCase/GetMemberNameUseCase.swift
+++ b/BeforeGoing/Domain/UseCase/GetMemberNameUseCase.swift
@@ -5,7 +5,11 @@
 //  Created by APPLE on 9/18/25.
 //
 
-struct GetMemberNameUseCase {
+protocol GetMemberNameType {
+    func execute() -> String
+}
+
+struct GetMemberNameUseCase: GetMemberNameType {
     
     private let repository: MemberInterface
     
@@ -16,5 +20,11 @@ struct GetMemberNameUseCase {
     func execute() -> String {
         let name = repository.getMemberName() ?? ""
         return name
+    }
+}
+
+struct MockGetMemberNameUseCase: GetMemberNameType {
+    func execute() -> String {
+        return "mock name"
     }
 }

--- a/BeforeGoing/Domain/UseCase/KakaoLoginUseCase.swift
+++ b/BeforeGoing/Domain/UseCase/KakaoLoginUseCase.swift
@@ -13,10 +13,10 @@ struct KakaoLoginUseCase {
         self.repository = repository
     }
     
-    func execute(provider: String) async throws {
+    func execute(provider: String) async throws -> Bool {
         let nonce = try await requestNonce(provider: provider)
         let idToken = try await repository.requestIDToken(nonce: nonce)
-        try await requestKakaoLogin(provider: provider, idToken: idToken)        
+        return try await requestKakaoLogin(provider: provider, idToken: idToken)        
     }
     
     private func requestNonce(provider: String) async throws -> String {
@@ -24,7 +24,7 @@ struct KakaoLoginUseCase {
         return nonceEntity.nonce
     }
     
-    private func requestKakaoLogin(provider: String, idToken: String) async throws {
-        try await repository.requestKakaoLogin(provider: provider, idToken: idToken)
+    private func requestKakaoLogin(provider: String, idToken: String) async throws -> Bool {
+        return try await repository.requestKakaoLogin(provider: provider, idToken: idToken)
     }
 }

--- a/BeforeGoing/Domain/UseCase/KakaoLoginUseCase.swift
+++ b/BeforeGoing/Domain/UseCase/KakaoLoginUseCase.swift
@@ -5,7 +5,11 @@
 //  Created by APPLE on 7/22/25.
 //
 
-struct KakaoLoginUseCase {
+protocol KakaoLoginType {
+    func execute(provider: String) async throws -> Bool
+}
+
+struct KakaoLoginUseCase: KakaoLoginType {
     
     private let repository: AuthInterface
     
@@ -26,5 +30,12 @@ struct KakaoLoginUseCase {
     
     private func requestKakaoLogin(provider: String, idToken: String) async throws -> Bool {
         return try await repository.requestKakaoLogin(provider: provider, idToken: idToken)
+    }
+}
+
+struct MockKakaoLoginUseCase: KakaoLoginType {
+    
+    func execute(provider: String) -> Bool {
+        return true
     }
 }

--- a/BeforeGoing/Domain/UseCase/LogoutUseCase.swift
+++ b/BeforeGoing/Domain/UseCase/LogoutUseCase.swift
@@ -5,7 +5,11 @@
 //  Created by APPLE on 9/13/25.
 //
 
-struct LogoutUseCase {
+protocol LogoutType {
+    func execute() async throws
+}
+
+struct LogoutUseCase: LogoutType {
     
     private let repository: AuthInterface
     
@@ -16,4 +20,9 @@ struct LogoutUseCase {
     func execute() async throws {
         try await repository.logout()
     }
+}
+
+struct MockLogoutUseCase: LogoutType {
+    
+    func execute() {}
 }

--- a/BeforeGoing/Domain/UseCase/MemberWithdrawUseCase.swift
+++ b/BeforeGoing/Domain/UseCase/MemberWithdrawUseCase.swift
@@ -5,7 +5,12 @@
 //  Created by APPLE on 9/18/25.
 //
 
-struct MemberWithdrawUseCase {
+protocol MemberWithdrawType {
+    
+    func execute() async throws
+}
+
+struct MemberWithdrawUseCase: MemberWithdrawType {
     
     private let repository: MemberInterface
     
@@ -16,4 +21,9 @@ struct MemberWithdrawUseCase {
     func execute() async throws {
         try await repository.withdrawMember()
     }
+}
+
+struct MockMemberWithdrawUseCase: MemberWithdrawType {
+    
+    func execute() {}
 }

--- a/BeforeGoing/Domain/UseCase/SendAgreeTermsUseCase.swift
+++ b/BeforeGoing/Domain/UseCase/SendAgreeTermsUseCase.swift
@@ -5,7 +5,17 @@
 //  Created by APPLE on 9/17/25.
 //
 
-struct SendAgreeTermsUseCase {
+protocol SendAgreeTermsType {
+    
+    func execute(
+        termsOfServiceAgreed: Bool,
+        privacyPolicyAgreed: Bool,
+        isOver14: Bool,
+        eventPushAgreed: Bool
+    ) async throws
+}
+
+struct SendAgreeTermsUseCase: SendAgreeTermsType {
     
     private let repository: TermsInterface
     
@@ -26,4 +36,14 @@ struct SendAgreeTermsUseCase {
             eventPushAgreed: eventPushAgreed
         )
     }
+}
+
+struct MockSendAgreeTermsUseCase: SendAgreeTermsType {
+    
+    func execute(
+        termsOfServiceAgreed: Bool,
+        privacyPolicyAgreed: Bool,
+        isOver14: Bool,
+        eventPushAgreed: Bool
+    ) {}
 }

--- a/BeforeGoing/Domain/UseCase/UpdateNicknameUseCase.swift
+++ b/BeforeGoing/Domain/UseCase/UpdateNicknameUseCase.swift
@@ -5,7 +5,12 @@
 //  Created by APPLE on 9/17/25.
 //
 
-struct UpdateNicknameUseCase {
+protocol UpdateNicknameType {
+    
+    func execute(nickname: String) async throws
+}
+
+struct UpdateNicknameUseCase: UpdateNicknameType {
     
     private let repository: MemberInterface
     
@@ -16,4 +21,9 @@ struct UpdateNicknameUseCase {
     func execute(nickname: String) async throws {
         try await repository.updateNickname(nickname: nickname)
     }
+}
+
+struct MockUpdateNicknameUseCase: UpdateNicknameType {
+    
+    func execute(nickname: String) {}
 }

--- a/BeforeGoing/Domain/UseCase/UpdatePushNoticeUseCase.swift
+++ b/BeforeGoing/Domain/UseCase/UpdatePushNoticeUseCase.swift
@@ -5,7 +5,12 @@
 //  Created by APPLE on 9/17/25.
 //
 
-struct UpdatePushNoticeUseCase {
+protocol UpdatePushNoticeType {
+    
+    func execute(eventPushAgreed: Bool) async throws
+}
+
+struct UpdatePushNoticeUseCase: UpdatePushNoticeType {
     
     private let repository: TermsInterface
     
@@ -16,4 +21,9 @@ struct UpdatePushNoticeUseCase {
     func execute(eventPushAgreed: Bool) async throws {
         try await repository.updateAgreementTerm(eventPushAgreed: eventPushAgreed)
     }
+}
+
+struct MockUpdatePushNoticeUseCase: UpdatePushNoticeType {
+    
+    func execute(eventPushAgreed: Bool) {}
 }

--- a/BeforeGoing/Presentation/Common/Modal/ModalType.swift
+++ b/BeforeGoing/Presentation/Common/Modal/ModalType.swift
@@ -7,7 +7,7 @@
 
 enum ModalType {
     
-    case expirationLogin, withdraw
+    case expirationLogin, logout, withdraw
     
     var component: ModalComponent {
         switch self {
@@ -16,6 +16,14 @@ enum ModalType {
                 image: .worry,
                 mainTitle: "로그인이 만료되었어요",
                 description: "더 안전한 앱 사용을 위해\n다시 로그인 해주세요:)",
+                dismissTitle: "취소",
+                actionTitle: "확인"
+            )
+        case .logout:
+            return .init(
+                image: .worry,
+                mainTitle: "로그아웃",
+                description: "로그아웃하시겠어요?",
                 dismissTitle: "취소",
                 actionTitle: "확인"
             )

--- a/BeforeGoing/Presentation/Feature/Approach/ViewController/LoginViewController.swift
+++ b/BeforeGoing/Presentation/Feature/Approach/ViewController/LoginViewController.swift
@@ -39,12 +39,8 @@ extension LoginViewController {
     func kakaoLoginButtonDidTap() {
         Task {
             do {
-                try await viewModel.action(input: .kakaoLoginDidTap)
-                // 이미 있는 회원이라면 홈
-                // 첫 회원가입이라면 약관동의로 이동
-                let viewController = ViewControllerFactory.shared.makeAgreeTermsViewController()
-                viewController.navigationItem.hidesBackButton = true
-                self.navigationController?.pushViewController(viewController, animated: true)
+                let output = try await viewModel.action(input: .kakaoLoginDidTap)
+                output.result ? moveHome() : moveTerms()
             } catch(let error) {
                 BeforeGoingLogger.error(error)
             }
@@ -54,5 +50,16 @@ extension LoginViewController {
     @objc
     func appleLoginButtonDidTap() {
         print("Apple Did Tap")
+    }
+    
+    private func moveHome() {
+        let viewController = BottomNavigationViewController()
+        ViewControllerUtil.shared.replaceRootViewController(to: viewController)
+    }
+    
+    private func moveTerms() {
+        let viewController = ViewControllerFactory.shared.makeAgreeTermsViewController()
+        viewController.navigationItem.hidesBackButton = true
+        self.navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/BeforeGoing/Presentation/Feature/Approach/ViewController/SplashViewController.swift
+++ b/BeforeGoing/Presentation/Feature/Approach/ViewController/SplashViewController.swift
@@ -38,6 +38,7 @@ final class SplashViewController: BaseViewController {
                 }
             } catch {
                 BeforeGoingLogger.error(BeforeGoingError.autoLoginFailed)
+                moveLogin()
             }
         }
     }

--- a/BeforeGoing/Presentation/Feature/Approach/ViewController/SplashViewController.swift
+++ b/BeforeGoing/Presentation/Feature/Approach/ViewController/SplashViewController.swift
@@ -28,35 +28,32 @@ final class SplashViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
                 
+        Task {
+            do {
+                let output = try await viewModel.action(input: .viewDidLoad)
+                
+                switch output {
+                case .autoLogin(let isSucceedAutoLogin):
+                    isSucceedAutoLogin ? moveHome() : moveLogin()
+                }
+            } catch {
+                BeforeGoingLogger.error(BeforeGoingError.autoLoginFailed)
+            }
+        }
+    }
+    
+    private func moveHome() {
+        let viewController = BottomNavigationViewController()
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            let viewController = ViewControllerFactory.shared.makeLoginViewController()
+            ViewControllerUtil.shared.replaceRootViewController(to: viewController)
+        }
+    }
+    
+    private func moveLogin() {
+        let viewController = ViewControllerFactory.shared.makeLoginViewController()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             viewController.navigationItem.hidesBackButton = true
             self.navigationController?.pushViewController(viewController, animated: true)
         }
-        // 추후 주석 제거 예정
-//        Task {
-//            do {
-//                var viewController: UIViewController
-//                let output = try await viewModel.action(input: .viewDidLoad)
-//                
-//                switch output {
-//                case .autoLogin(let isSucceedAutoLogin):
-//                    if isSucceedAutoLogin {
-//                        viewController = BottomNavigationViewController()
-//                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-//                            ViewControllerUtil.shared.replaceRootViewController(to: viewController)
-//                        }
-//                    } else {
-//                        viewController = ViewControllerFactory.shared.makeLoginViewController()
-//                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-//                            viewController.navigationItem.hidesBackButton = true
-//                            self.navigationController?.pushViewController(viewController, animated: true)
-//                        }
-//                    }
-//                }
-//            } catch {
-//                BeforeGoingLogger.error(BeforeGoingError.autoLoginFailed)
-//            }
-//        }
     }
 }

--- a/BeforeGoing/Presentation/Feature/Approach/ViewModel/AgreeItemViewModel.swift
+++ b/BeforeGoing/Presentation/Feature/Approach/ViewModel/AgreeItemViewModel.swift
@@ -9,7 +9,7 @@ final class AgreeItemViewModel: ViewModeling {
     
     private var agreeItems = AgreeItem.allCases
     private var checkBoxStates: [AgreeItem : CheckBoxState] = [:]
-    private let useCase: SendAgreeTermsUseCase
+    private let useCase: SendAgreeTermsType
     
     enum Input {
         case nextButtonDidTap
@@ -18,7 +18,7 @@ final class AgreeItemViewModel: ViewModeling {
         case agreeTermsResult(Bool)
     }
     
-    init(useCase: SendAgreeTermsUseCase) {
+    init(useCase: SendAgreeTermsType) {
         self.useCase = useCase
         agreeItems.forEach { checkBoxStates[$0] = .unchecked }
     }

--- a/BeforeGoing/Presentation/Feature/Approach/ViewModel/LoginViewModel.swift
+++ b/BeforeGoing/Presentation/Feature/Approach/ViewModel/LoginViewModel.swift
@@ -18,15 +18,15 @@ final class LoginViewModel: ViewModeling {
         //case appleLoginDidTap
     }
     
-    enum Output {
-        case kakaoLoginResult
+    struct Output {
+        let result: Bool
     }
     
     func action(input: Input) async throws -> Output {
         switch input {
         case .kakaoLoginDidTap:
-            try await kakaoLoginUseCase.execute(provider: Provider.kakao.rawValue)
-            return .kakaoLoginResult
+            let isRegisteredMember = try await kakaoLoginUseCase.execute(provider: Provider.kakao.rawValue)
+            return .init(result: isRegisteredMember)
         }
     }
 }

--- a/BeforeGoing/Presentation/Feature/Approach/ViewModel/LoginViewModel.swift
+++ b/BeforeGoing/Presentation/Feature/Approach/ViewModel/LoginViewModel.swift
@@ -7,9 +7,9 @@
 
 final class LoginViewModel: ViewModeling {
     
-    private let kakaoLoginUseCase: KakaoLoginUseCase
+    private let kakaoLoginUseCase: KakaoLoginType
     
-    init(kakaoLoginUseCase: KakaoLoginUseCase) {
+    init(kakaoLoginUseCase: KakaoLoginType) {
         self.kakaoLoginUseCase = kakaoLoginUseCase
     }
     

--- a/BeforeGoing/Presentation/Feature/Approach/ViewModel/NicknameViewModel.swift
+++ b/BeforeGoing/Presentation/Feature/Approach/ViewModel/NicknameViewModel.swift
@@ -7,9 +7,9 @@
 
 final class NicknameViewModel: ViewModeling {
     
-    private let useCase: UpdateNicknameUseCase
+    private let useCase: UpdateNicknameType
     
-    init(useCase: UpdateNicknameUseCase) {
+    init(useCase: UpdateNicknameType) {
         self.useCase = useCase
     }
     

--- a/BeforeGoing/Presentation/Feature/Approach/ViewModel/SplashViewModel.swift
+++ b/BeforeGoing/Presentation/Feature/Approach/ViewModel/SplashViewModel.swift
@@ -7,9 +7,9 @@
 
 final class SplashViewModel: ViewModeling {
     
-    private let useCase: AutoLoginUseCase
+    private let useCase: AutoLoginType
     
-    init(useCase: AutoLoginUseCase) {
+    init(useCase: AutoLoginType) {
         self.useCase = useCase
     }
     

--- a/BeforeGoing/Presentation/Feature/Setting/ViewController/ProfileViewController.swift
+++ b/BeforeGoing/Presentation/Feature/Setting/ViewController/ProfileViewController.swift
@@ -80,42 +80,71 @@ extension ProfileViewController {
     
     @objc
     private func logoutButtonDidTap() {
-        Task {
-            guard let result = try await viewModel.action(input: .logoutButtonDidTap) as? ProfileViewModel.LogoutOutput else {
-                return
-            }
-            if result.isSucceedLogout {
-                let loginViewController = ViewControllerFactory.shared.makeLoginViewController()
-                ViewControllerUtil.shared.replaceRootViewController(to: loginViewController)
-                return
-            }
-            BeforeGoingLogger.error(BeforeGoingError.logoutFailed)
-        }
+        presentModal(modalType: .logout)
     }
     
     @objc
     private func withdrawButtonDidTap() {
+        presentModal(modalType: .withdraw)
+    }
+    
+    private func presentModal(modalType: ModalType) {
+        var action: () -> Void
+        
+        switch modalType {
+        case .expirationLogin:
+            action = {}
+        case .logout:
+            action = defineLogout()
+        case .withdraw:
+            action = defineWithdrawal()
+        }
+        
         let viewController = ModalViewController(
-            modalView: ModalView(type: .withdraw),
-            action: { [weak self] in
-                guard let self = self else { return }
-                Task {
-                    guard let result = try await self.viewModel.action(
-                        input: .withdrawButtonDidTap
-                    ) as? ProfileViewModel.WithdrawOutput else {
-                        return
-                    }
-                    if result.isSucceedWithdraw {
-                        self.dismiss(animated: false)
-                        let viewController = ViewControllerFactory.shared.makeLoginViewController()
-                        let navigationController = UINavigationController(rootViewController: viewController)
-                        ViewControllerUtil.shared.replaceRootViewController(to: navigationController)
-                        return
-                    }
-                }
-            }
+            modalView: ModalView(type: modalType),
+            action: action
         )
         viewController.modalPresentationStyle = .overFullScreen
         self.present(viewController, animated: true)
+    }
+    
+    private func defineLogout() -> () -> Void {
+        return { [weak self] in
+            guard let self = self else { return }
+            Task {
+                guard let result = try await self.viewModel.action(
+                    input: .logoutButtonDidTap
+                ) as? ProfileViewModel.LogoutOutput else {
+                    return
+                }
+                if result.isSucceedLogout {
+                    let loginViewController = ViewControllerFactory.shared.makeLoginViewController()
+                    ViewControllerUtil.shared.replaceRootViewController(to: loginViewController)
+                    return
+                }
+                BeforeGoingLogger.error(BeforeGoingError.logoutFailed)
+            }
+        }
+    }
+    
+    private func defineWithdrawal() -> () -> Void {
+        return { [weak self] in
+            guard let self = self else { return }
+            Task {
+                guard let result = try await self.viewModel.action(
+                    input: .withdrawButtonDidTap
+                ) as? ProfileViewModel.WithdrawOutput else {
+                    return
+                }
+                if result.isSucceedWithdraw {
+                    self.dismiss(animated: false)
+                    
+                    let viewController = ViewControllerFactory.shared.makeLoginViewController()
+                    let navigationController = UINavigationController(rootViewController: viewController)
+                    ViewControllerUtil.shared.replaceRootViewController(to: navigationController)
+                    return
+                }
+            }
+        }
     }
 }

--- a/BeforeGoing/Presentation/Feature/Setting/ViewModel/ModifyNicknameViewModel.swift
+++ b/BeforeGoing/Presentation/Feature/Setting/ViewModel/ModifyNicknameViewModel.swift
@@ -7,9 +7,9 @@
 
 final class ModifyNicknameViewModel: ViewModeling {
     
-    private let useCase: UpdateNicknameUseCase
+    private let useCase: UpdateNicknameType
     
-    init(useCase: UpdateNicknameUseCase) {
+    init(useCase: UpdateNicknameType) {
         self.useCase = useCase
     }
     

--- a/BeforeGoing/Presentation/Feature/Setting/ViewModel/ProfileViewModel.swift
+++ b/BeforeGoing/Presentation/Feature/Setting/ViewModel/ProfileViewModel.swift
@@ -9,14 +9,14 @@ protocol ProfileOutput {}
 
 final class ProfileViewModel: ViewModeling {
     
-    private let getMemberNameUseCase: GetMemberNameUseCase
-    private let logoutUseCase: LogoutUseCase
-    private let withdrawUseCase: MemberWithdrawUseCase
+    private let getMemberNameUseCase: GetMemberNameType
+    private let logoutUseCase: LogoutType
+    private let withdrawUseCase: MemberWithdrawType
     
     init(
-        getMemberNameUseCase: GetMemberNameUseCase,
-        logoutUseCase: LogoutUseCase,
-        withdrawUseCase: MemberWithdrawUseCase
+        getMemberNameUseCase: GetMemberNameType,
+        logoutUseCase: LogoutType,
+        withdrawUseCase: MemberWithdrawType
     ) {
         self.getMemberNameUseCase = getMemberNameUseCase
         self.logoutUseCase = logoutUseCase

--- a/BeforeGoing/Presentation/Feature/Setting/ViewModel/SettingViewModel.swift
+++ b/BeforeGoing/Presentation/Feature/Setting/ViewModel/SettingViewModel.swift
@@ -9,10 +9,13 @@ protocol SettingOutput {}
 
 final class SettingViewModel: ViewModeling {
     
-    private let fetchAgreeTermsUseCase: FetchAgreeTermsUseCase
-    private let updatePushNoticeUseCase: UpdatePushNoticeUseCase
+    private let fetchAgreeTermsUseCase: FetchAgreeTermsType
+    private let updatePushNoticeUseCase: UpdatePushNoticeType
     
-    init(fetchAgreeTermsUseCase: FetchAgreeTermsUseCase, updatePushNoticeUseCase: UpdatePushNoticeUseCase) {
+    init(
+        fetchAgreeTermsUseCase: FetchAgreeTermsType,
+        updatePushNoticeUseCase: UpdatePushNoticeType
+    ) {
         self.fetchAgreeTermsUseCase = fetchAgreeTermsUseCase
         self.updatePushNoticeUseCase = updatePushNoticeUseCase
     }

--- a/BeforeGoing/Presentation/PresentationDependencyAssembler.swift
+++ b/BeforeGoing/Presentation/PresentationDependencyAssembler.swift
@@ -21,7 +21,7 @@ struct PresentationDependencyAssembler: DependencyAssembler {
             fatalError()
         }
         
-        guard let autoLoginUseCase: AutoLoginUseCase = DIContainer.shared.resolve() else {
+        guard let autoLoginUseCase = DIContainer.shared.resolve(type: AutoLoginType.self) else {
             BeforeGoingLogger.error(BeforeGoingError.diContainerError)
             fatalError()
         }

--- a/BeforeGoing/Presentation/PresentationDependencyAssembler.swift
+++ b/BeforeGoing/Presentation/PresentationDependencyAssembler.swift
@@ -16,7 +16,7 @@ struct PresentationDependencyAssembler: DependencyAssembler {
     func assemble() {
         domainDependencyAssembler.assemble()
         
-        guard let kakaoLoginUseCase: KakaoLoginUseCase = DIContainer.shared.resolve() else {
+        guard let kakaoLoginUseCase = DIContainer.shared.resolve(type: KakaoLoginType.self) else {
             BeforeGoingLogger.error(BeforeGoingError.diContainerError)
             fatalError()
         }
@@ -26,37 +26,37 @@ struct PresentationDependencyAssembler: DependencyAssembler {
             fatalError()
         }
         
-        guard let logoutUseCase: LogoutUseCase = DIContainer.shared.resolve() else {
+        guard let logoutUseCase = DIContainer.shared.resolve(type: LogoutType.self) else {
             BeforeGoingLogger.error(BeforeGoingError.diContainerError)
             fatalError()
         }
         
-        guard let agreeTermsUseCase: SendAgreeTermsUseCase = DIContainer.shared.resolve() else {
+        guard let agreeTermsUseCase = DIContainer.shared.resolve(type: SendAgreeTermsType.self) else {
             BeforeGoingLogger.error(BeforeGoingError.diContainerError)
             fatalError()
         }
         
-        guard let updatePushNoticeUseCase: UpdatePushNoticeUseCase = DIContainer.shared.resolve() else {
+        guard let updatePushNoticeUseCase = DIContainer.shared.resolve(type: UpdatePushNoticeType.self) else {
             BeforeGoingLogger.error(BeforeGoingError.diContainerError)
             fatalError()
         }
         
-        guard let updateNicknameUseCase: UpdateNicknameUseCase = DIContainer.shared.resolve() else {
+        guard let updateNicknameUseCase = DIContainer.shared.resolve(type: UpdateNicknameType.self) else {
             BeforeGoingLogger.error(BeforeGoingError.diContainerError)
             fatalError()
         }
         
-        guard let getMemberNameUseCase: GetMemberNameUseCase = DIContainer.shared.resolve() else {
+        guard let getMemberNameUseCase = DIContainer.shared.resolve(type: GetMemberNameType.self) else {
             BeforeGoingLogger.error(BeforeGoingError.diContainerError)
             fatalError()
         }
         
-        guard let withdrawUseCase: MemberWithdrawUseCase = DIContainer.shared.resolve() else {
+        guard let withdrawUseCase = DIContainer.shared.resolve(type: MemberWithdrawType.self) else {
             BeforeGoingLogger.error(BeforeGoingError.diContainerError)
             fatalError()
         }
         
-        guard let fetchAgreeTermsUseCase: FetchAgreeTermsUseCase = DIContainer.shared.resolve() else {
+        guard let fetchAgreeTermsUseCase = DIContainer.shared.resolve(type: FetchAgreeTermsType.self) else {
             BeforeGoingLogger.error(BeforeGoingError.diContainerError)
             fatalError()
         }

--- a/BeforeGoingUITests/BeforeGoingUITests.swift
+++ b/BeforeGoingUITests/BeforeGoingUITests.swift
@@ -26,7 +26,7 @@ final class BeforeGoingUITests: XCTestCase {
     func testExample() throws {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
-        app.launchEnvironment = ["USE_MOCK_AUTOLOGIN": "true"]
+        app.launchEnvironment = ["USE_MOCK": "true"]
         app.launch()
         
         // Use XCTAssert and related functions to verify your tests produce the correct results.
@@ -38,7 +38,7 @@ final class BeforeGoingUITests: XCTestCase {
             // This measures how long it takes to launch your application.
             measure(metrics: [XCTApplicationLaunchMetric()]) {
                 let app = XCUIApplication()
-                app.launchEnvironment = ["USE_MOCK_AUTOLOGIN": "true"]
+                app.launchEnvironment = ["USE_MOCK": "true"]
                 app.launch()
             }
         }

--- a/BeforeGoingUITests/BeforeGoingUITests.swift
+++ b/BeforeGoingUITests/BeforeGoingUITests.swift
@@ -26,6 +26,7 @@ final class BeforeGoingUITests: XCTestCase {
     func testExample() throws {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
+        app.launchEnvironment = ["USE_MOCK_AUTOLOGIN": "true"]
         app.launch()
         
         // Use XCTAssert and related functions to verify your tests produce the correct results.
@@ -36,7 +37,9 @@ final class BeforeGoingUITests: XCTestCase {
         if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
             // This measures how long it takes to launch your application.
             measure(metrics: [XCTApplicationLaunchMetric()]) {
-                XCUIApplication().launch()
+                let app = XCUIApplication()
+                app.launchEnvironment = ["USE_MOCK_AUTOLOGIN": "true"]
+                app.launch()
             }
         }
     }

--- a/BeforeGoingUITests/BeforeGoingUITestsLaunchTests.swift
+++ b/BeforeGoingUITests/BeforeGoingUITestsLaunchTests.swift
@@ -20,7 +20,7 @@ final class BeforeGoingUITestsLaunchTests: XCTestCase {
     @MainActor
     func testLaunch() throws {
         let app = XCUIApplication()
-        app.launchEnvironment = ["USE_MOCK_AUTOLOGIN": "true"]
+        app.launchEnvironment = ["USE_MOCK": "true"]
         app.launch()
 
         // Insert steps here to perform after app launch but before taking a screenshot,

--- a/BeforeGoingUITests/BeforeGoingUITestsLaunchTests.swift
+++ b/BeforeGoingUITests/BeforeGoingUITestsLaunchTests.swift
@@ -20,6 +20,7 @@ final class BeforeGoingUITestsLaunchTests: XCTestCase {
     @MainActor
     func testLaunch() throws {
         let app = XCUIApplication()
+        app.launchEnvironment = ["USE_MOCK_AUTOLOGIN": "true"]
         app.launch()
 
         // Insert steps here to perform after app launch but before taking a screenshot,

--- a/BeforeGoingUITests/BeforeGoingUITestsLaunchTests.swift
+++ b/BeforeGoingUITests/BeforeGoingUITestsLaunchTests.swift
@@ -28,7 +28,7 @@ final class BeforeGoingUITestsLaunchTests: XCTestCase {
 
         let attachment = XCTAttachment(screenshot: app.screenshot())
         attachment.name = "Launch Screen"
-        attachment.lifetime = .keepAlways
+        attachment.lifetime = .deleteOnSuccess
         add(attachment)
     }
 }

--- a/BeforeGoingUITests/BeforeGoingUITestsLaunchTests.swift
+++ b/BeforeGoingUITests/BeforeGoingUITestsLaunchTests.swift
@@ -25,10 +25,5 @@ final class BeforeGoingUITestsLaunchTests: XCTestCase {
 
         // Insert steps here to perform after app launch but before taking a screenshot,
         // such as logging into a test account or navigating somewhere in the app
-
-        let attachment = XCTAttachment(screenshot: app.screenshot())
-        attachment.name = "Launch Screen"
-        attachment.lifetime = .deleteOnSuccess
-        add(attachment)
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,8 @@ platform :ios do
       result_bundle: true,
       code_coverage: true,
       output_directory: ".",
-      output_types: "junit,xcresult"
+      output_types: "junit,xcresult",
+      skip_testing: ["BeforeGoingUITests"]
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,8 +25,7 @@ platform :ios do
       result_bundle: true,
       code_coverage: true,
       output_directory: ".",
-      output_types: "junit,xcresult",
-      skip_testing: ["BeforeGoingUITests"]
+      output_types: "junit,xcresult"
     )
   end
 


### PR DESCRIPTION
### ✅ PR 타입
- [ ] feat: 새로운 기능 추가
- [ ] refactor: 코드 리펙토링

### 🪾 반영 브랜치
feat/#47-autoLogin-> dev

### ✨ 변경 사항
- 자동 로그인을 구현했습니다.
- 로그인 화면에서 등록된 회원인지 여부에 따라 화면 이동을 분기처리했습니다.

### 💯 테스트 결과
**[자동 로그인에 성공한 경우]**

![자동로그인된 경우](https://github.com/user-attachments/assets/d3648f78-c136-4839-b798-47c812d71833)

**[로그아웃 이후 앱에 진입한 경우 (회원가입은 이미 완료한 경우)]**

![자동로그인X](https://github.com/user-attachments/assets/03923ec7-a99c-4f02-a377-5212f7b3fe0b)

**[앱에 처음 진입하거나 회원 탈퇴후 재접속한 경우]**

![회원등록X](https://github.com/user-attachments/assets/86bf1ff4-73ca-4317-81ad-90f249629091)


### 📂 관련 이슈
#47 