### PR TITLE
Refactor/#91 앱 종료 시 이벤트 알림이 꺼지는 현상 수정

### DIFF
--- a/BeforeGoing/Presentation/Feature/Notification/NotificationViewController.swift
+++ b/BeforeGoing/Presentation/Feature/Notification/NotificationViewController.swift
@@ -43,6 +43,12 @@ final class NotificationViewController: BaseViewController {
         AudioManager.shared.startSound()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        AudioManager.shared.stopSound()
+    }
+    
     override func setAction() {
         rootView.actionButtons.forEach {
             switch $0.value {
@@ -67,13 +73,11 @@ extension NotificationViewController {
     
     @objc
     private func turnOffNotificationDidTap() {
-        AudioManager.shared.stopSound()
         replaceToHome()
     }
     
     @objc
     private func againNotificationDidTap() {
-        AudioManager.shared.stopSound()
         replaceToHome()
         NotificationManager.shared.reserveSnooze(
             originalContent: self.content,

--- a/BeforeGoing/Presentation/Feature/Setting/ViewController/SettingViewController.swift
+++ b/BeforeGoing/Presentation/Feature/Setting/ViewController/SettingViewController.swift
@@ -31,25 +31,9 @@ final class SettingViewController: BaseViewController {
     override func loadView() {
         view = rootView
     }
-    
+        
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        Task {
-            guard let result = try await viewModel.action(
-                input: .viewWillAppear
-            ) as? SettingViewModel.EventPushAgreedOutput else {
-                return
-            }
-            
-            switch result.isEventPushAgreed {
-            case .success(let eventPushAgreed):
-                rootView.settingNoticeView.eventPushNoticeView.updateSwitch(isAgreed: eventPushAgreed)
-            case .failure(let error):
-                self.handleError(error)
-                BeforeGoingLogger.error(error)
-            }
-        }
         
         NotificationCenter.default.addObserver(
             self,
@@ -71,6 +55,7 @@ final class SettingViewController: BaseViewController {
         
         checkPushNoticeAuthorization()
         checkLocationAuthorization()
+        checkEventPush()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -227,6 +212,24 @@ extension SettingViewController: NetworkRequestable, NetworkRequestErrorHandler 
     @objc
     private func privacyButtonDidTap() {
         ExternalLink.privacy.openURL(for: self)
+    }
+    
+    private func checkEventPush() {
+        Task {
+            guard let result = try await viewModel.action(
+                input: .viewWillAppear
+            ) as? SettingViewModel.EventPushAgreedOutput else {
+                return
+            }
+            
+            switch result.isEventPushAgreed {
+            case .success(let eventPushAgreed):
+                rootView.settingNoticeView.eventPushNoticeView.updateSwitch(isAgreed: eventPushAgreed)
+            case .failure(let error):
+                self.handleError(error)
+                BeforeGoingLogger.error(error)
+            }
+        }
     }
     
     private func alertEventPushChange(isSwitchedOn: Bool) {


### PR DESCRIPTION
### ✅ PR 타입
- [ ] refactor: 코드 리펙토링

### 🪾 반영 브랜치
refactor/#91-eventPush -> dev

### ✨ 변경 사항
- viewWillAppear에서 이벤트 알림 동의 여부 체크

### 📂 관련 이슈
#91 