### PR TITLE
Refactor/#91 다른 날짜 선택 시 시나리오, 텍스트필드 표출 수정

### DIFF
--- a/BeforeGoing/Presentation/Common/Calendar/CalendarViewController.swift
+++ b/BeforeGoing/Presentation/Common/Calendar/CalendarViewController.swift
@@ -26,7 +26,7 @@ final class CalendarViewController: BaseViewController {
         }
         return date
     }
-    private lazy var selectedDate = currentDate
+    lazy var selectedDate = currentDate
     private var selectableStartDate: Date?
     private var selectableEndDate: Date?
     private let formatter: DateFormatter = {

--- a/BeforeGoing/Presentation/Feature/Home/View/HomeHeaderView.swift
+++ b/BeforeGoing/Presentation/Feature/Home/View/HomeHeaderView.swift
@@ -115,12 +115,11 @@ final class HomeHeaderView: BaseView {
         }
         bubbleView.snp.makeConstraints {
             $0.top.equalTo(dateStackView.snp.bottom).offset(16.adjustedH)
-            $0.leading.greaterThanOrEqualToSuperview().inset(20.adjustedW)
-            $0.trailing.lessThanOrEqualToSuperview().inset(20.adjustedW)
+            $0.leading.greaterThanOrEqualToSuperview().inset(5.adjustedW)
+            $0.trailing.lessThanOrEqualToSuperview().inset(5.adjustedW)
             $0.centerX.equalToSuperview()
             $0.height.equalTo(62.adjustedH)
         }
-
         wordLabel.snp.makeConstraints {
             $0.edges.equalToSuperview().inset(
                 UIEdgeInsets(top: 8, left: 25, bottom: 8, right: 25)

--- a/BeforeGoing/Presentation/Feature/Home/View/UserScenarioModalView.swift
+++ b/BeforeGoing/Presentation/Feature/Home/View/UserScenarioModalView.swift
@@ -140,13 +140,12 @@ extension UserScenarioModalView {
         taskTextField.text = completeText
     }
     
-    func updatePlaceHolder(text: String) {
-        taskTextField.placeholder = text
-    }
-    
-    func updateTaskField(isEnable: Bool) {
-        taskTextField.currentType = isEnable ? .enableAddField : .disableAddField
-        taskTextField.isEnabled = isEnable
+    func updateTaskField(isEnabled: Bool, text: String) {
+        taskTextField.do {
+            $0.currentType = isEnabled ? .enableAddField : .disableAddField
+            $0.isEnabled = isEnabled
+            $0.placeholder = text
+        }
     }
     
     func enableAddTaskButton() {

--- a/BeforeGoing/Presentation/Feature/Home/ViewController/HomeViewController.swift
+++ b/BeforeGoing/Presentation/Feature/Home/ViewController/HomeViewController.swift
@@ -12,6 +12,7 @@ import UIKit
 final class HomeViewController: BaseViewController {
     
     private let rootView = HomeView()
+    private let calendarViewController = CalendarViewController()
     private let homeViewModel: HomeViewModel
     private let getScenariosViewModel: GetAllScenariosViewModel
     private let locationManager = CLLocationManager()
@@ -40,19 +41,19 @@ final class HomeViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        let selectedDate = calendarViewController.selectedDate
+        let dateString = DateUtil.toAPIDateString(date: selectedDate)
+        
+        getScenarios(currentDate: dateString)
         checkLoactionAuthorization()
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        let currentDate = DateUtil.getCurrentDate()
-        let currentDateString = DateUtil.getCurrentDate(format: "yyyy-MM-dd")
-        
+                
         setLocationManager()
         requestDate()
-        getScenarios(currentDate: currentDateString)
-        updateWeatherInformation(date: currentDate)
+        updateWeatherInformation(date: DateUtil.getCurrentDate())
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -270,13 +271,12 @@ extension HomeViewController: ToastPresentable {
     
     @objc
     private func viewCalendarButtonDidTap() {
-        let calendar = CalendarViewController()
-        calendar.modalPresentationStyle = .overFullScreen
+        calendarViewController.modalPresentationStyle = .overFullScreen
         
-        initSelectedDate(calendar: calendar)
+        initSelectedDate(calendarViewController: calendarViewController)
         
-        calendar.onDayDidTap = { [weak self] date in
-            let dateString = DateUtil.toString(date: date)
+        calendarViewController.onDayDidTap = { [weak self] date in
+            let dateString = DateUtil.toHomeDateString(date: date)
             let currentDate = DateUtil.getCurrentDate()
             
             guard let self = self,
@@ -293,7 +293,7 @@ extension HomeViewController: ToastPresentable {
             
             updateWeatherInformation(date: date)
         }
-        calendar.onDismiss = { [weak self] in
+        calendarViewController.onDismiss = { [weak self] in
             guard let homeDate = self?.homeDate,
                   let date = DateUtil.convertDateFormat(dateString: homeDate) else {
                 return
@@ -301,7 +301,7 @@ extension HomeViewController: ToastPresentable {
             
             self?.getScenarios(currentDate: date)
         }
-        self.present(calendar, animated: true)
+        self.present(calendarViewController, animated: true)
     }
     
     @objc
@@ -410,12 +410,12 @@ extension HomeViewController: ToastPresentable {
         pushManageScenario(navigationController: navigationController)
     }
     
-    private func initSelectedDate(calendar: CalendarViewController) {
+    private func initSelectedDate(calendarViewController: CalendarViewController) {
         if let homeDateString = self.homeDate,
            let date = DateUtil.toDate(dateString: homeDateString) {
-            calendar.initialSelectedDate = date
+            calendarViewController.initialSelectedDate = date
         } else {
-            calendar.initialSelectedDate = DateUtil.getCurrentDate()
+            calendarViewController.initialSelectedDate = DateUtil.getCurrentDate()
         }
     }
     

--- a/BeforeGoing/Presentation/Feature/Home/ViewController/HomeViewController.swift
+++ b/BeforeGoing/Presentation/Feature/Home/ViewController/HomeViewController.swift
@@ -62,6 +62,7 @@ final class HomeViewController: BaseViewController {
     
     override func setAction() {
         setGesture()
+        
         rootView.headerView.viewCalendarButton.addTarget(
             self,
             action: #selector(viewCalendarButtonDidTap),
@@ -115,8 +116,10 @@ final class HomeViewController: BaseViewController {
                 }
                 self.homeDate = result.date
                 rootView.headerView.updateDateUI(date: result.date)
-                rootView.modalView.updatePlaceHolder(text: "\(monthAndDay)의 미션을 추가해요")
-                rootView.modalView.updateTaskField(isEnable: true)
+                rootView.modalView.updateTaskField(
+                    isEnabled: true,
+                    text: "\(monthAndDay)의 미션을 추가해요"
+                )
             } catch (let error) {
                 self.handleError(error)
                 BeforeGoingLogger.error(error)
@@ -424,7 +427,7 @@ extension HomeViewController: ToastPresentable {
     ) {
         self.homeDate = dateString
         updateHeaderDate(date: dateString)
-        updatePlaceHolderByDate(
+        updateTaskByDate(
             date: date,
             currentDate: currentDate,
             monthAndDay: monthAndDay
@@ -457,22 +460,22 @@ extension HomeViewController: ToastPresentable {
         self.rootView.headerView.updateDateUI(date: date)
     }
     
-    private func updatePlaceHolderByDate(
+    private func updateTaskByDate(
         date: Date,
         currentDate: Date,
         monthAndDay: String
     ) {
         if date >= currentDate {
-            self.rootView.modalView.do {
-                $0.updatePlaceHolder(text: "\(monthAndDay)의 미션을 추가해요")
-                $0.updateTaskField(isEnable: true)
-            }
+            self.rootView.modalView.updateTaskField(
+                isEnabled: true,
+                text: "\(monthAndDay)의 미션을 추가해요"
+            )
             return
         }
-        self.rootView.modalView.do {
-            $0.updatePlaceHolder(text: "지난 날짜의 리스트는 추가할 수 없어요")
-            $0.updateTaskField(isEnable: false)
-        }
+        self.rootView.modalView.updateTaskField(
+            isEnabled: false,
+            text: "지난 날짜의 리스트는 추가할 수 없어요"
+        )
     }
     
     private func moveScenarioTab() -> BottomNavigationViewController? {

--- a/BeforeGoing/Presentation/Feature/Home/ViewController/HomeViewController.swift
+++ b/BeforeGoing/Presentation/Feature/Home/ViewController/HomeViewController.swift
@@ -40,19 +40,19 @@ final class HomeViewController: BaseViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        let currentDate = DateUtil.getCurrentDate()
-        let currentDateString = DateUtil.getCurrentDate(format: "yyyy-MM-dd")
-        
-        getScenarios(currentDate: currentDateString)
         checkLoactionAuthorization()
-        updateWeatherInformation(date: currentDate)
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        let currentDate = DateUtil.getCurrentDate()
+        let currentDateString = DateUtil.getCurrentDate(format: "yyyy-MM-dd")
+        
         setLocationManager()
         requestDate()
+        getScenarios(currentDate: currentDateString)
+        updateWeatherInformation(date: currentDate)
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/BeforeGoing/Presentation/Util/DateUtil.swift
+++ b/BeforeGoing/Presentation/Util/DateUtil.swift
@@ -64,8 +64,12 @@ struct DateUtil {
         return dateFormatter.string(from: date)
     }
     
-    static func toString(date: Date) -> String {
+    static func toHomeDateString(date: Date) -> String {
         return homeDateformatter.string(from: date)
+    }
+    
+    static func toAPIDateString(date: Date) -> String {
+        return apiDateFormatter.string(from: date)
     }
     
     static func toDate(dateString: String) -> Date? {


### PR DESCRIPTION
### ✅ PR 타입
- [ ] refactor: 코드 리펙토링

### 🪾 반영 브랜치
refactor/#91-otherDate -> dev

### ✨ 변경 사항
- 홈에서 오늘이 아닌 날짜를 선택하고 다른 화면에 다녀왔을 때 해당 날짜의 시나리오, 텍스트필드 속 placeHolder를 정상적으로 표출하도록 수정

### 📂 관련 이슈
#91 